### PR TITLE
Fix kustomize install CRD command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install kubectl. For more details, see: https://kubernetes.io/docs/tasks/tools/i
 To install CRDs use the following command:
 
 ```shell
-kustomize build github.com/bitpoke/wordpress-operator/config/crd | kubectl apply -f-
+kubectl apply -f https://raw.githubusercontent.com/bitpoke/wordpress-operator/master/config/crd/bases/wordpress.presslabs.org_wordpresses.yaml
 ```
 
 ### Install controller


### PR DESCRIPTION
The provided command in the Readme for installing the CRD does not work. 
It fails with the following error: 
```shell
$ kustomize build github.com/bitpoke/wordpress-operator/config/crd | kubectl apply -f-
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/private/var/folders/3g/zsywd2f96kn44ms_nkqc9qx40000gn/T/kustomize-3277046403/config/crd'
error: no objects passed to apply
```

I propose to use kubectl instead.