### PR TITLE
Allow Operator to run with a RoleBinding

### DIFF
--- a/cmd/wordpress-operator/main.go
+++ b/cmd/wordpress-operator/main.go
@@ -62,8 +62,8 @@ func main() {
 		HealthProbeBindAddress:     options.HealthProbeBindAddress,
 	}
 
-	if options.ScopedNamespace != "" {
-		opt.Namespace = options.ScopedNamespace
+	if options.WatchNamespace != "" {
+		opt.Namespace = options.WatchNamespace
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/wordpress-operator/main.go
+++ b/cmd/wordpress-operator/main.go
@@ -54,15 +54,21 @@ func main() {
 		os.Exit(genericErrorExitCode)
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{
+	opt := manager.Options{
 		LeaderElection:             options.LeaderElection,
 		LeaderElectionID:           options.LeaderElectionID,
 		LeaderElectionNamespace:    options.LeaderElectionNamespace,
 		LeaderElectionResourceLock: "leases",
 		MetricsBindAddress:         options.MetricsBindAddress,
 		HealthProbeBindAddress:     options.HealthProbeBindAddress,
-	})
+	}
+
+	if options.ScopedNamespace != "" {
+		opt.Namespace = options.ScopedNamespace
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, opt)
 	if err != nil {
 		setupLog.Error(err, "unable to create a new manager")
 		os.Exit(genericErrorExitCode)

--- a/cmd/wordpress-operator/main.go
+++ b/cmd/wordpress-operator/main.go
@@ -44,7 +44,6 @@ func main() {
 	flag.Parse()
 
 	logf.SetLogger(klogr.New())
-
 	setupLog.Info("Starting wordpress-operator...")
 
 	// Get a config to talk to the apiserver

--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -51,6 +51,8 @@ var (
 
 	// HealthProbeBindAddress is the TCP address that the controller should bind to for serving health probes.
 	HealthProbeBindAddress = ":8081"
+
+	ScopedNamespace = os.Getenv("SCOPED_NAMESPACE")
 )
 
 func namespace() string {

--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -52,7 +52,8 @@ var (
 	// HealthProbeBindAddress is the TCP address that the controller should bind to for serving health probes.
 	HealthProbeBindAddress = ":8081"
 
-	ScopedNamespace = os.Getenv("SCOPED_NAMESPACE")
+	// WatchNamespace sets the Namespace field, which restricts the manager's cache to watch objects in the desired namespace.
+	WatchNamespace = os.Getenv("WATCH_NAMESPACE")
 )
 
 func namespace() string {


### PR DESCRIPTION
Currently, the operator requires a ClusterRoleBinding to watch resources at a cluster level. We would like the operator to be able to run isolated to a specific namespace. 

This PR would allow us to do that, by conditionally adding in [a Namespace field to the manager](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L195), which would be enabled by an environment variable. The operator would then be able to use a RoleBinding rather than a ClusterRoleBinding.

Please let me know the preferred method of documenting this functionality, as well as any improvements to the suggested changes.