### PR TITLE
Pass Down Wordpress Resource Specs to 'install-wp' initContainer

### DIFF
--- a/hack/Dockerfile.skaffold
+++ b/hack/Dockerfile.skaffold
@@ -1,5 +1,5 @@
 # Build the dashboard binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 ARG BUILD_DATE=""
 ARG GIT_COMMIT="unavailable"

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -491,6 +491,7 @@ func (wp *Wordpress) installWPContainer() []corev1.Container {
 			VolumeMounts:    wp.volumeMounts(),
 			Env:             append(wp.env(), wp.Spec.WordpressBootstrapSpec.Env...),
 			EnvFrom:         append(wp.envFrom(), wp.Spec.WordpressBootstrapSpec.EnvFrom...),
+			Resources:       wp.Spec.Resources,
 			SecurityContext: wp.securityContext(),
 			Command:         []string{"wp-install"},
 			Args: []string{


### PR DESCRIPTION
Wordpress deployment will fail to create pods on a namespace that requires resources to be defined.

+ Bump version of golang in Dockerfile.skaffold as it was not building on 1.13